### PR TITLE
Closes #10 + repo name update

### DIFF
--- a/cni.html
+++ b/cni.html
@@ -157,8 +157,8 @@
 			<small class="terms"
 				>(C) 2022 Listenbourg -
 				<a href="https://twitter.com/DevListenbourg">Twitter</a> -
-				<a href="https://github.com/Listenbourg/GenerateurCNI">GitHub</a> -
-				<a href="https://github.com/Listenbourg/GenerateurCNI/issues"
+				<a href="https://github.com/Listenbourg/ListenPASS">GitHub</a> -
+				<a href="https://github.com/Listenbourg/ListenPASS/issues"
 					>Signaler un problème</a
 				></small
 			>

--- a/index.html
+++ b/index.html
@@ -90,8 +90,8 @@
 			<small class="terms"
 				>(C) 2022 Listenbourg -
 				<a href="https://twitter.com/DevListenbourg">Twitter</a> -
-				<a href="https://github.com/Listenbourg/GenerateurCNI">GitHub</a> -
-				<a href="https://github.com/Listenbourg/GenerateurCNI/issues"
+				<a href="https://github.com/Listenbourg/ListenPASS">GitHub</a> -
+				<a href="https://github.com/Listenbourg/ListenPASS/issues"
 					>Signaler un problème</a
 				></small
 			>

--- a/passeport.html
+++ b/passeport.html
@@ -157,7 +157,7 @@
 					</button>
 					<button
 						class="downloadButton disabled"
-						onclick="DownloadIDForm('cni-listenbourg.png')"
+						onclick="DownloadIDForm('passport-listenbourg.png')"
 					>
 						<span class="material-symbols-outlined">
 							file_download

--- a/passeport.html
+++ b/passeport.html
@@ -169,8 +169,8 @@
 			<small class="terms"
 				>(C) 2022 Listenbourg -
 				<a href="https://twitter.com/DevListenbourg">Twitter</a> -
-				<a href="https://github.com/Listenbourg/GenerateurCNI">GitHub</a> -
-				<a href="https://github.com/Listenbourg/GenerateurCNI/issues"
+				<a href="https://github.com/Listenbourg/ListenPASS">GitHub</a> -
+				<a href="https://github.com/Listenbourg/ListenPASS/issues"
 					>Signaler un problème</a
 				></small
 			>


### PR DESCRIPTION
Hi!
- Fixed #10, the passport file is now downloaded as `passport-listenbourg.png`
- Changed the links to this repo from `Listenbourg/GenerateurCNI` to `Listenbourg/ListenPASS`

If needed, I speak fluent French and Spanish.