### PR TITLE
fix: country code of Listenbourg is LIS

### DIFF
--- a/js/passeport.js
+++ b/js/passeport.js
@@ -63,7 +63,7 @@ const canvadraw = async (
 		passport: {
 			mrzType: "td3",
 			type: "p",
-			issuingCountry: "LSB",
+			issuingCountry: "LIS",
 			number: passportNum,
 			expirationDate: new Date(date_expi.split("/").reverse().join("-")),
 		},


### PR DESCRIPTION
Bonjour,
Voici un petit commit pour corriger une incohérence dans le code pays du Listenbourg sur le Passeport.
Sur la MRZ il est indiqué `LSB` au lieu de `LIS` comme indiqué sur le document d'identité.