### PR TITLE
fix: nationality is LIS, not LSB

### DIFF
--- a/js/passeport.js
+++ b/js/passeport.js
@@ -76,7 +76,7 @@ const canvadraw = async (
 				.trim()
 				.toUpperCase()
 				.slice(0, 15 /* max length for the machine-readable zone */),
-			nationality: "LSB",
+			nationality: "LIS",
 			dateOfBirth: new Date(date_naissance.split("/").reverse().join("-")),
 			sex: sexe,
 		},


### PR DESCRIPTION
I propose to keep the same country code throughout the document (LIS) as well as in the MRZ for the nationality code.